### PR TITLE
feat: Raspbian用のログインスクリプトの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,24 @@ Don't work Python3.7 for Windows.
 8. Run `pipenv run python ./miyadai_login.py`
 9. Perform clone setting.(参照: [Ubuntuで定期自動ログインする
 ](https://github.com/korosuke613/miyadai-sso-auto-login/wiki/Ubuntu%E3%81%A7%E5%AE%9A%E6%9C%9F%E8%87%AA%E5%8B%95%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B))
+
+### Raspbian
+
+1. Open terminal.
+1. Run `sudo apt install libffi-dev`
+1. Run `sudo pip install cffi`
+1. Run `sudo pip install secretstorage`
+1. Run `sudo pip install pipenv`
+1. Install chromedriver
+    1. Run `sudo apt install chromium-chromedriver`
+    1. If the above is OK, next 7.
+    1. Else, run `wget https://github.com/electron/electron/releases/download/v1.6.0/chromedriver-v2.21-linux-armv7l.zip`
+    1. Run `unzip chromedriver-v2.21-linux-armv7l.zip -d /open/your/path/chromedriver`
+1. Edit 17 line to `        driver_path = "/path/in/your/chromedriver/chromedriver"`
+1. Run `git clone --depth=1 https://github.com/korosuke613/miyadai-sso-auto-login.git`
+1. Run `cd miyadai-sso-auto-login`
+1. Run `pipenv install`
+1. Run `pipenv run python ./save_pass_in_raspbian.py`
+1. Run `pipenv run python ./miyadai_login_in_raspbian.py`
+1. Perform clone setting.(参照: [Ubuntuで定期自動ログインする
+](https://github.com/korosuke613/miyadai-sso-auto-login/wiki/Ubuntu%E3%81%A7%E5%AE%9A%E6%9C%9F%E8%87%AA%E5%8B%95%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B))

--- a/miyadai_login_in_raspbian.py
+++ b/miyadai_login_in_raspbian.py
@@ -1,0 +1,71 @@
+"""
+selenium自動ログイン
+"""
+import platform
+
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+
+
+def login(mid):
+    # WebDriverのパスを指定してChromeを起動
+    os_name = platform.system()
+    if os_name == "Linux":
+        driver_path = ""
+    else:
+        print("Unknown System. Please send Issue.")
+        return
+    if driver_path is "":
+        print("Please edit driver_path in 17 line!")
+        return
+    driver = webdriver.Chrome(driver_path)
+
+    # Yahooのページをブラウザで開きます
+    miyadai_url = "https://www.miyazaki-u.ac.jp/"
+    driver.get(miyadai_url)
+    print(driver.current_url)
+    try:
+        WebDriverWait(driver, 10).until(lambda driver: driver.current_url != miyadai_url)
+        login_url = driver.current_url
+        print(login_url)
+        input_mid = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "login-username")))
+        print(driver.current_url)
+    except TimeoutException:
+        print("Already login or don't connecting.")
+        driver.quit()
+        return
+
+    input_mid.send_keys(mid[0])
+    input_pass = driver.find_element_by_id("login-password")
+    input_pass.send_keys(mid[1])
+
+    # 検索ボタン要素の取得
+    button_login = driver.find_element_by_id("btn-login")
+
+    # 検索ボタンをクリックする
+    button_login.click()
+
+    try:
+        WebDriverWait(driver, 10).until(lambda driver: driver.current_url != login_url)
+        print(driver.current_url)
+    except TimeoutException:
+        print("Failed login. Please check MID or password.")
+    driver.quit()
+    return
+
+
+def read_user_file():
+    path = 'user.txt'
+    name_and_path = [];
+    with open(path, mode='r') as f:
+        name_and_path.append(f.readline().replace('\n', ''))
+        name_and_path.append(f.readline())
+    return name_and_path
+
+
+if __name__ == '__main__':
+    mid = read_user_file()
+    login(mid)

--- a/save_pass_in_raspbian.py
+++ b/save_pass_in_raspbian.py
@@ -1,0 +1,26 @@
+from getpass import getpass
+
+
+def save_password_to_os():
+    mid = input("Please input MID: ")
+    password = getpass(prompt='Please input password(It does not display): ')
+    retry_password = getpass(prompt='Please input password again(It does not display): ')
+
+    # OSにパスワード保存(1回実行すれば良い)
+    if password == retry_password:
+        create_user_file(mid, password)
+        print("Success! Store your login info.")
+    else:
+        print("Don't same password! Please again.")
+
+
+def create_user_file(name, passwd):
+    path_w = 'user.txt'
+    with open(path_w, mode='w') as f:
+        f.write(name)
+        f.write('\n')
+        f.write(passwd)
+
+
+if __name__ == '__main__':
+    save_password_to_os()


### PR DESCRIPTION
Raspbian用のログインスクリプトを記述しました。
その際に、通常のスクリプトとは異なるラズパイオリジナルのスクリプトを作成しました。

## 追加点

- secretstorageに必要であったcffiの導入手順を追加
- chromedriverの導入手順を追加
    - aptコマンドでインストールできる場合はそれでよし
    - そうでない場合はホームページからバイナリファイルを直接取ってくる必要あり
- Raspbian用のスクリプトの記述
    - chromedriverのパスは上記の導入時に個人で異なるため、記述するよう要請
    - パスワード保存のためのkeyringは実行できなかったため、user.txtファイルにユーザ名とパスワードを保存するよう修正

上記のままでは動かない可能性があります（原因究明の紆余曲折な結果による原因の特定不足）。
一応メモ程度にしてください。
もし実機で確認できる場合は幸いです。

## 実行環境

- Raspberry Pi 3B
- Linux raspberrypi 4.9.35-v7+ \#1014