### PR TITLE
feat: ページのロード時間を短縮

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Don't work Python3.7 for Windows.
 
 ### Raspbian
 
-__Caution__
-
+__!!!Caution!!!__
 This script cannot run at Raspberry Pi ZERO!
 Please run at Raspberry Pi using __armv7l__!
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ miyadai-sso-auto-login is auto login system in University of Miyazaki.
 
 ## install
 Please install Python3.6.6 in advance.
-Don't work Python3.7 for Windows. 
+Don't work Python3.7 for Windows.
 
 ### Windows
 1. Open PowerShell with Administrator.
@@ -32,19 +32,26 @@ Don't work Python3.7 for Windows.
 
 ### Raspbian
 
-1. Open terminal.
+__Caution__
+
+This script cannot run at Raspberry Pi ZERO!
+Please run at Raspberry Pi using __armv7l__!
+
+Checking method: Run `uname -a`
+
+1. Open terminal
 1. Run `sudo apt install libffi-dev`
 1. Run `sudo pip install cffi`
 1. Run `sudo pip install secretstorage`
 1. Run `sudo pip install pipenv`
 1. Install chromedriver
     1. Run `sudo apt install chromium-chromedriver`
-    1. If the above is OK, next 7.
+    1. If the above is OK, next 7
     1. Else, run `wget https://github.com/electron/electron/releases/download/v1.6.0/chromedriver-v2.21-linux-armv7l.zip`
     1. Run `unzip chromedriver-v2.21-linux-armv7l.zip -d /open/your/path/chromedriver`
 1. Run `git clone --depth=1 https://github.com/korosuke613/miyadai-sso-auto-login.git`
 1. Run `cd miyadai-sso-auto-login`
-1. Edit 17 line to `        driver_path = "/path/in/your/chromedriver/chromedriver"`
+1. Edit 17 line to `        driver_path = "/path/in/your/chromedriver/chromedriver"` in miyadai_login_in_raspbian.py
 1. Run `pipenv --python 3.6.6 install`
 1. Run `pipenv install selenium`
 1. Run `pipenv run python ./save_pass_in_raspbian.py`

--- a/miyadai_login.py
+++ b/miyadai_login.py
@@ -30,7 +30,7 @@ def login(mid):
         return
     driver = webdriver.Chrome(driver_path)
 
-    # Yahooのページをブラウザで開きます
+    # 宮崎大学公式ホームページをブラウザで開きます
     miyadai_url = "https://www.miyazaki-u.ac.jp/"
     driver.get(miyadai_url)
     print(driver.current_url)

--- a/miyadai_login_in_raspbian.py
+++ b/miyadai_login_in_raspbian.py
@@ -22,12 +22,14 @@ def login(mid):
         print("Please edit driver_path in 17 line!")
         return
     driver = webdriver.Chrome(driver_path)
+    driver.set_page_load_timeout(10)
 
-    # Yahooのページをブラウザで開きます
-    miyadai_url = "https://www.miyazaki-u.ac.jp/"
-    driver.get(miyadai_url)
-    print(driver.current_url)
     try:
+        # 宮崎大学公式ホームページをブラウザで開きます
+        miyadai_url = "https://www.miyazaki-u.ac.jp/"
+        driver.get(miyadai_url)
+        print(driver.current_url)
+
         WebDriverWait(driver, 10).until(lambda driver: driver.current_url != miyadai_url)
         login_url = driver.current_url
         print(login_url)


### PR DESCRIPTION
Raspberry PiではTimeoutExceptionにかなりの時間を要するため、タイムアウトまでの時間を短縮しました。
これにより、ネットワーク回路復活にかかる時間を短縮できます。

- ページのロード時間を短縮
    - ページ取得時の振舞いをtry構文内に移転
    - コメント欄の修正
- READMEの修正
    - 修正箇所のファイル名を追記
    - Raspberry Pi ZEROでは動かない旨を記述

よろしくお願いいたします。